### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/doc/specs.md
+++ b/doc/specs.md
@@ -1,4 +1,4 @@
-#Specs
+# Specs
 
 This document tries to describe how to use specs with *mekao*.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
